### PR TITLE
Check for metadata changes, redownload if changed

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,8 @@ const sbBackup = new SbBackup({
     s3Settings: {
       accessKeyId: '',
       secretAccessKey: ''
-    }
+    },
+    metadata: true
 })
 
 sbBackup.backupSpace(123456)
@@ -27,6 +28,7 @@ The settings of the constructor of the class `SbBackup` are:
 - **basePath**: optional, defaults to `./backups` - this is the path of the backup folder in case you are performing a local backup;
 - **s3Settings.accessKeyId**: optional - this is the IAM access key id for authentication on your S3 bucket;  
 - **s3Settings.secretAccessKey**: optional - this is the IAM secret access key for authentication on your S3 bucket.
+- **metadata**: optional, defaults to `true` - indicates if metadata should be checked for updates. If metadata changed the asset will be backed up again.
 
 ## Methods
 All instances of the `SbBackup` class can perform 2 actions: backup a space or backup all the spaces.

--- a/src/backup.js
+++ b/src/backup.js
@@ -59,7 +59,7 @@ export default class SbBackup {
         assets = (await this.getAssets(spaceId)).filter(asset => {
           const match = backedUpAssets.find(bAsset => bAsset.id === asset.id)
           if (match) {
-            return new Date(asset.updated_at) > new Date(match.updated_at) 
+            return asset.updated_at !== match.updated_at
           } else {
             return true
           }

--- a/src/backup.js
+++ b/src/backup.js
@@ -57,11 +57,12 @@ export default class SbBackup {
       if (this.metadata) {
         const backedUpAssets = await this.storage.backedupAssets()
         assets = (await this.getAssets(spaceId)).filter(asset => {
-          return backedUpAssets.filter(bAsset => {
-            if (bAsset.id === asset.id) {
-              return new Date(bAsset.updated_at) < new Date(asset.updated_at)
-            } 
-          }).length
+          const matches = backedUpAssets.filter(bAsset => bAsset.id === asset.id)
+          if (matches.length) {
+            return new Date(asset.updated_at) > new Date(matches.pop().updated_at) 
+          } else {
+            return true
+          }
         })
       } else {
         const backedUpAssetsIds = await this.storage.backedupAssetsIds()

--- a/src/backup.js
+++ b/src/backup.js
@@ -57,9 +57,9 @@ export default class SbBackup {
       if (this.metadata) {
         const backedUpAssets = await this.storage.backedupAssets()
         assets = (await this.getAssets(spaceId)).filter(asset => {
-          const matches = backedUpAssets.filter(bAsset => bAsset.id === asset.id)
-          if (matches.length) {
-            return new Date(asset.updated_at) > new Date(matches.pop().updated_at) 
+          const match = backedUpAssets.find(bAsset => bAsset.id === asset.id)
+          if (match) {
+            return new Date(asset.updated_at) > new Date(match.updated_at) 
           } else {
             return true
           }

--- a/src/storage/backup-storage.js
+++ b/src/storage/backup-storage.js
@@ -33,10 +33,10 @@ export default class BackupStorage {
           console.log(`Error backing up ${asset.filename}`)
         }
       }, (err) => {
-        if(err) {
+        if (err) {
           return reject(false)
         }
-        if(typeof this.afterBackupCallback === 'function') {
+        if (typeof this.afterBackupCallback === 'function') {
           this.afterBackupCallback()
         }
         return resolve(true)
@@ -57,7 +57,7 @@ export default class BackupStorage {
    * Return the list of the assets already backed up.
    * @returns {Array} An array of asset objects
    */
-  async backedupAssets () {
+  async backedupAssets() {
     console.log('You forgot to override the "backedupAssets" method')
   }
 
@@ -70,7 +70,7 @@ export default class BackupStorage {
   async backupAsset(asset) {
     console.log('You forgot to override the "backupAsset" method')
   }
-  
+
   /**
    * The space directory
    */
@@ -95,7 +95,7 @@ export default class BackupStorage {
   async downloadAsset(asset) {
     const filename = asset.filename.split('/').pop()
     const file = fs.createWriteStream(`${this.getAssetDirectory(asset)}/${filename}`)
-    
+
     return new Promise((resolve, reject) => {
       https.get(asset.filename, (res) => {
         if (res.statusCode === 200) {

--- a/src/storage/backup-storage.js
+++ b/src/storage/backup-storage.js
@@ -54,6 +54,14 @@ export default class BackupStorage {
   }
 
   /**
+   * Return the list of the assets already backed up.
+   * @returns {Array} An array of asset objects
+   */
+  async backedupAssets () {
+    console.log('You forgot to override the "backedupAssets" method')
+  }
+
+  /**
    * Backs up an asset. It must return true or false depending on the success
    * of the action
    * @param {Object} asset The asset object from Storyblok

--- a/src/storage/local.js
+++ b/src/storage/local.js
@@ -20,14 +20,19 @@ export default class LocalStorage extends BackupStorage {
    */
   async backedupAssets() {
     const assetIds = await this.backedupAssetsIds()
-    return assetIds.map((assetId) => {
+    const assets = []
+    for (const assetId of assetIds) {
       const metaDataFile = fs.readdirSync(`${this.spaceDirectory}/${assetId}`, { withFileTypes: true })
         .find(dirEntry => dirEntry.name.startsWith('sb_asset_data_'))
-      return {
-        id: assetId,
-        updated_at: metaDataFile.name.match(/sb_asset_data_(.*).json/)[1]
+      const timestamp = metaDataFile?.name?.match(/sb_asset_data_(.*).json/)[1]
+      if (timestamp) {
+        assets.push({
+          id: assetId,
+          updated_at: timestamp
+        })
       }
-    })
+    }
+    return assets
   }
 
   /**

--- a/src/storage/local.js
+++ b/src/storage/local.js
@@ -18,6 +18,17 @@ export default class LocalStorage extends BackupStorage {
   /**
    * Override of the default method
    */
+  async backedupAssets () {
+    return (await this.backedupAssetsIds()).map(assetId => 
+      JSON.parse(
+        fs.readFileSync(`${this.spaceDirectory}/${assetId}/sb_asset_data.json`)
+      )
+    )
+  }
+
+  /**
+   * Override of the default method
+   */
   async backupAsset(asset) {
     if (!fs.existsSync(this.getAssetDirectory(asset))) {
       fs.mkdirSync(this.getAssetDirectory(asset), { recursive: true })

--- a/src/storage/s3.js
+++ b/src/storage/s3.js
@@ -24,6 +24,24 @@ export default class S3Storage extends BackupStorage {
   /**
    * Override of the default method
    */
+   async backedupAssets() {
+    return (await this.backedupAssetsIds()).map((assetId) =>
+      JSON.parse(
+        (
+          await this.s3Client
+            .getObject({
+              Bucket: this.bucket,
+              Key: `${this.spaceId}/${assetId}/sb_asset_data.json`,
+            })
+            .promise()
+        ).Body.toString('utf-8')
+      )
+    )
+  }
+
+  /**
+   * Override of the default method
+   */
   async backupAsset(asset) {
     if (!fs.existsSync(this.getAssetDirectory(asset))) {
       fs.mkdirSync(this.getAssetDirectory(asset), { recursive: true })

--- a/src/storage/s3.js
+++ b/src/storage/s3.js
@@ -25,7 +25,7 @@ export default class S3Storage extends BackupStorage {
    * Override of the default method
    */
    async backedupAssets() {
-    return (await this.backedupAssetsIds()).map((assetId) =>
+    return (await this.backedupAssetsIds()).map(async (assetId) =>
       JSON.parse(
         (
           await this.s3Client


### PR DESCRIPTION
As we do not have a checksum for the file contents, and there is the possibility to replace assets in place, we can not be sure if the file contents changed. Therefore assets are downloaded again if metadata checking is enabled and changes in the metadata were detected.

Please check the s3 implementation again before merging :)  