### PR TITLE
Fixes temp not being deleted in some cases 

### DIFF
--- a/src/backup.js
+++ b/src/backup.js
@@ -58,9 +58,9 @@ export default class SbBackup {
         console.log(`✓ Assets of space ${spaceId} backed up correctly`)
       } else {
         console.log(`✓ No new assets to backup in space ${spaceId}`)
-        if (typeof this.storage.afterBackupCallback === 'function') {
-          this.storage.afterBackupCallback()
-        }
+      }
+      if (typeof this.storage.afterBackupCallback === 'function') {
+        this.storage.afterBackupCallback()
       }
     } catch (err) {
       console.error(err)

--- a/src/backup.js
+++ b/src/backup.js
@@ -58,6 +58,9 @@ export default class SbBackup {
         console.log(`✓ Assets of space ${spaceId} backed up correctly`)
       } else {
         console.log(`✓ No new assets to backup in space ${spaceId}`)
+        if (typeof this.storage.afterBackupCallback === 'function') {
+          this.storage.afterBackupCallback()
+        }
       }
     } catch (err) {
       console.error(err)

--- a/src/storage/backup-storage.js
+++ b/src/storage/backup-storage.js
@@ -42,9 +42,6 @@ export default class BackupStorage {
         if (err) {
           return reject(false)
         }
-        if (typeof this.afterBackupCallback === 'function') {
-          this.afterBackupCallback()
-        }
         return resolve(true)
       })
     })


### PR DESCRIPTION
When no assets were backed up in the s3 strategy, the `temp` folder created in `storage.setSpace` would not be deleted from the `afterBackupCallback` because it didn't get executed.
This executes the callback even if there were no assets to back up.